### PR TITLE
Clean find

### DIFF
--- a/find.py
+++ b/find.py
@@ -46,13 +46,6 @@ args = parser.parse_args()
 
 
 # Functions
-def parse_addr(addr):
-    if "x" in addr.lower():
-        address = int(addr, 16)
-    else:
-        address = int(addr, 10)
-    return address
-
 def do_test(filename, addr_queue, machine, abicls, tests_cls, map_addr, quiet,
             timeout, jitter, verbose):
 
@@ -75,8 +68,8 @@ def do_test(filename, addr_queue, machine, abicls, tests_cls, map_addr, quiet,
 
 # Parse args
 machine = Machine(args.architecture)
-addresses = map(parse_addr, args.address)
-map_addr = parse_addr(args.mapping_base)
+addresses = [int(addr, 0) for addr in args.address]
+map_addr = int(args.mapping_base, 0)
 found = False
 for abicls in ABIS:
     if args.abi == abicls.__name__:

--- a/find.py
+++ b/find.py
@@ -127,4 +127,4 @@ for p in processes:
     p.join()
 
 if not queue.empty():
-    print("An error occured: queue is not empty")
+    raise RuntimeError("An error occured: queue is not empty")

--- a/find.py
+++ b/find.py
@@ -70,13 +70,12 @@ def do_test(filename, addr_queue, machine, abicls, tests_cls, map_addr, quiet,
 machine = Machine(args.architecture)
 addresses = [int(addr, 0) for addr in args.address]
 map_addr = int(args.mapping_base, 0)
-found = False
+
 for abicls in ABIS:
     if args.abi == abicls.__name__:
-        found = True
         break
-if not found:
-    raise ValueError("Unknown ABI name")
+else:
+    raise ValueError("Unknown ABI name: %s" % args.abi)
 tests = []
 for tname, tcases in AVAILABLE_TESTS.items():
     if "all" in args.tests or tname in args.tests:


### PR DESCRIPTION
Few improvement to `find.py`, notably a `--monoproc` option to disable the multiprocessing (useful for debugging purpose)