### PR TITLE
Func heuristic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,5 @@ before_script:
 - "export SIBYL=$(pwd)/Sibyl;"
 script:
 - "cd $SIBYL/c_tests && python run_ctests.py;"
+- "cd $SIBYL/c_tests && python run_ctests.py -f -a;"
 - "cd $SIBYLTEST && ./run.sh;"

--- a/c_tests/run_ctests.py
+++ b/c_tests/run_ctests.py
@@ -2,8 +2,16 @@
 import os
 import re
 import subprocess
+from argparse import ArgumentParser
 
 from elfesteem.elf_init import ELF
+
+parser = ArgumentParser("Regression tester")
+parser.add_argument("-f", "--func-heuristic", action="store_true",
+                    help="Enable function addresses detection heuristics")
+parser.add_argument("-a", "--arch-heuristic", action="store_true",
+                    help="Enable architecture detection heuristics")
+args = parser.parse_args()
 
 custom_tag = "my_"
 whitelist_funcs = ["main"]
@@ -66,9 +74,13 @@ for c_file in c_files:
 
     # Launch Sibyl
     print "[+] Launch Sibyl"
-    cmd = ["python", "../find.py", filename, "ABIStdCall_x86_32",
-           "-q"]
-    cmd += [hex(addr) for addr, f in to_check]
+    options = ["-q"]
+    if not args.arch_heuristic:
+        options += ["-a", "x86_32"]
+
+    cmd = ["python", "../find.py"] + options + [filename, "ABIStdCall_x86_32"]
+    if not args.func_heuristic:
+        cmd += [hex(addr) for addr, f in to_check]
     print " ".join(cmd)
     sibyl = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)

--- a/sibyl/heuristics/csts.py
+++ b/sibyl/heuristics/csts.py
@@ -1,0 +1,28 @@
+"Common constants for heuristics"
+
+
+# Function prologs and epilogs binary pattern, mainly ripped from archinfo
+# (project Angr)
+
+# arch name -> list of regexp expression
+func_prologs = {
+    'x86_32': [
+        r"\x55\x8b\xec", # push ebp; mov ebp, esp
+        r"\x55\x89\xe5",  # push ebp; mov ebp, esp
+    ],
+    'arml': [
+        r"[\x00-\xff][\x00-\xff]\x2d\xe9",          # stmfd sp!, {xxxxx}
+        r"\x04\xe0\x2d\xe5",                        # push {lr}
+    ],
+}
+func_epilogs = {
+    'x86_32': [
+        r"\xc9\xc3", # leave; ret
+        r"([^\x41][\x50-\x5f]{1}|\x41[\x50-\x5f])\xc3", # pop <reg>; ret
+        r"[^\x48][\x83,\x81]\xc4([\x00-\xff]{1}|[\x00-\xff]{4})\xc3", #  add esp, <siz>; retq
+    ],
+    'arml': [
+        r"[\x00-\xff]{2}\xbd\xe8\x1e\xff\x2f\xe1"   # pop {xxx}; bx lr
+        r"\x04\xe0\x9d\xe4\x1e\xff\x2f\xe1"         # pop {xxx}; bx lr
+    ],
+}

--- a/sibyl/heuristics/func.py
+++ b/sibyl/heuristics/func.py
@@ -1,0 +1,67 @@
+"Module for function address guessing"
+import logging
+
+from miasm2.core.asmbloc import asm_block_bad, log_asmbloc
+
+from sibyl.heuristics.heuristic import Heuristic
+
+def recursive_call(func_heur, start_addr=None):
+
+    # Prepare disassembly engine
+    dis_engine = func_heur.machine.dis_engine
+    cont = func_heur.cont
+    mdis = dis_engine(cont.bin_stream, symbol_pool=cont.symbol_pool)
+    if start_addr is None:
+        start_addr = cont.entry_point
+    mdis.follow_call = True
+
+    # Launch disassembly
+    cur_log_level = log_asmbloc.level
+    log_asmbloc.setLevel(logging.CRITICAL)
+    cfg = mdis.dis_multibloc(start_addr)
+    log_asmbloc.setLevel(cur_log_level)
+
+    # Find potential addresses
+    addresses = {}
+    for bbl in cfg.nodes():
+        if len(bbl.lines) == 0:
+            continue
+        last_line = bbl.lines[-1]
+        if last_line.is_subcall():
+            for succ in cfg.successors(bbl):
+                if cfg.edges2constraint[(bbl, succ)] != "c_to":
+                    continue
+
+                # Avoid redirectors
+                if len(succ.lines) == 0 or succ.lines[0].dstflow():
+                    continue
+
+                # Avoid unmapped block and others relative bugs
+                if isinstance(succ, asm_block_bad):
+                    continue
+
+                addresses[succ.label.offset] = 1
+
+    return addresses
+
+
+class FuncHeuristic(Heuristic):
+    """Provide heuristic for function start address detection"""
+
+    # Enabled passes
+    heuristics = [recursive_call]
+
+    def __init__(self, cont, machine):
+        """
+        @cont: miasm2's Container instance
+        @machine: miasm2's Machine instance
+        """
+        super(FuncHeuristic, self).__init__()
+        self.cont = cont
+        self.machine = machine
+
+    def guess(self):
+        for address, value in self.votes.iteritems():
+            # Heuristic may vote negatively
+            if value > 0:
+                yield address


### PR DESCRIPTION
Introduce heuristics to detect functions in binaries.

Firstly, prolog pattern are searched in the binary.
Secondly, for each function candidate, a recursive disassembler is used, fetching new candidates from subcalls.

(This PR is based on #9 and must be merged after)