### PR TITLE
Regtest bad found

### DIFF
--- a/c_tests/run_ctests.py
+++ b/c_tests/run_ctests.py
@@ -63,6 +63,8 @@ for c_file in c_files:
     symbols = {}
     for name, symb in elf.getsectionbyname(".symtab").symbols.iteritems():
         offset = symb.value
+        if name.startswith("__"):
+            name = name[2:]
         symbols.setdefault(name, set()).add(offset)
         if name in funcs:
             if name.startswith(custom_tag):

--- a/c_tests/run_ctests.py
+++ b/c_tests/run_ctests.py
@@ -78,7 +78,7 @@ for c_file in c_files:
 
     # Launch Sibyl
     print "[+] Launch Sibyl"
-    options = ["-q"]
+    options = ["-q", "-j", "gcc", "-i", "5"]
     if not args.arch_heuristic:
         options += ["-a", "x86_32"]
 


### PR DESCRIPTION
Some bad found in regression test are:
* correct guesses, but not asked
* correct guesses, but with a symbol name starting with `__`

The default jitter is switch to `gcc`:
```
TCC uncompiled : real	0m4.084s user	0m9.628s sys	0m0.692s
TCC compiled : real	0m3.598s user	0m8.036s sys	0m0.588s

GCC uncompiled : real	0m11.706s user	0m30.620s sys	0m3.936s (test_string 16/21 found)
GCC uncompiled 5sec timeout : real	0m11.904s user	0m31.908s sys	0m4.016s
GCC compiled : real	0m2.043s user	0m3.448s sys	0m0.248s
```

(This PR is based on #11 and must be merged after)
