### PR TITLE
TestLauncher: set alarm for gcc jitter

### DIFF
--- a/sibyl/testlauncher.py
+++ b/sibyl/testlauncher.py
@@ -110,7 +110,7 @@ class TestLauncher(object):
         # nor passed to Jitted code in case of registration with signal API
         if jit_engine == "python":
             signal.signal(signal.SIGALRM, TestLauncher._timeout)
-        elif jit_engine in ["llvm", "tcc"]:
+        elif jit_engine in ["llvm", "tcc", "gcc"]:
             self.jitter.vm.set_alarm()
 
     def init_abi(self, abicls):


### PR DESCRIPTION
Alarm is now also set for gcc jitter in sibyl/testlauncher.py.