### PR TITLE
QEMU emulation support (through Unicorn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,10 +244,19 @@ class TestA64l(test.Test):
 
 A more elaborated test can be found in _sibyl/test/ctype.py_.
 
+### Emulation engine
+
+A few emulation engine are supported. Through the `--jitter` option, one can
+specified:
+
+* `python`: use a full Python emulation
+* `tcc` or `gcc`: use a C compiler to JiT code (thanks to Miasm)
+* `qemu`: use the Unicorn (http://www.unicorn-engine.org/) QEMU binding
 
 Installation
 ------------
 _Sibyl_ requires the last version of _Miasm2_ and the corresponding version of _Elfesteem_.
+For the `qemu` engine, the `unicorn` python package must be installed (refer to the documentation of Unicorn for more detail).
 _Sibyl_ comes as a package, without _setup.py_ utility for now.
 One just needs to add the _Sibyl_ root directory to its _PYTHONPATH_ environment variable.
 

--- a/sibyl/commons.py
+++ b/sibyl/commons.py
@@ -18,4 +18,4 @@ class TimeoutException(Exception):
     pass
 
 
-END_ADDR = 0x1337beef
+END_ADDR = 0x1337babe

--- a/sibyl/commons.py
+++ b/sibyl/commons.py
@@ -1,0 +1,19 @@
+"""Common / shared elements"""
+import logging
+
+def init_logger(name):
+    logger = logging.getLogger(name)
+
+    console_handler = logging.StreamHandler()
+    log_format = "%(levelname)-5s: %(message)s"
+    console_handler.setFormatter(logging.Formatter(log_format))
+    logger.addHandler(console_handler)
+
+    logger.setLevel(logging.ERROR)
+    return logger
+
+
+class TimeoutException(Exception):
+    """Exception to be called on timeouts"""
+    pass
+

--- a/sibyl/commons.py
+++ b/sibyl/commons.py
@@ -17,3 +17,5 @@ class TimeoutException(Exception):
     """Exception to be called on timeouts"""
     pass
 
+
+END_ADDR = 0x1337beef

--- a/sibyl/engine/__init__.py
+++ b/sibyl/engine/__init__.py
@@ -1,0 +1,4 @@
+"""This module abstracts running engine"""
+
+from sibyl.engine.qemu import QEMUEngine
+from sibyl.engine.miasm import MiasmEngine

--- a/sibyl/engine/engine.py
+++ b/sibyl/engine/engine.py
@@ -1,0 +1,26 @@
+from sibyl.commons import init_logger
+
+
+class Engine(object):
+    """Wrapper on execution engine"""
+
+    def __init__(self, machine):
+        """Instanciate an Engine
+        @machine: miasm2.analysis.machine:Machine instance"""
+        self.logger = init_logger(self.__class__.__name__)
+
+    def take_snapshot(self):
+        self.vm_mem = self.jitter.vm.get_all_memory()
+        self.vm_regs = self.jitter.cpu.get_gpreg()
+
+    def restore_snapshot(self, memory=True):
+        raise NotImplementedError("Abstract method")
+
+    def run(self, address, timeout_seconds):
+        raise NotImplementedError("Abstract method")
+
+    def prepare_run(self):
+        pass
+
+    def restore_snapshot(self, memory=True):
+        raise NotImplementedError("Abstract method")

--- a/sibyl/engine/miasm.py
+++ b/sibyl/engine/miasm.py
@@ -1,7 +1,7 @@
 import signal
 
 from sibyl.engine.engine import Engine
-from sibyl.commons import TimeoutException
+from sibyl.commons import TimeoutException, END_ADDR
 
 
 class MiasmEngine(Engine):
@@ -9,7 +9,7 @@ class MiasmEngine(Engine):
 
     def __init__(self, machine, jit_engine):
         jitter = machine.jitter(jit_engine)
-        jitter.set_breakpoint(0x1337beef, MiasmEngine._code_sentinelle)
+        jitter.set_breakpoint(END_ADDR, MiasmEngine._code_sentinelle)
         self.jitter = jitter
 
         # Signal handling

--- a/sibyl/engine/miasm.py
+++ b/sibyl/engine/miasm.py
@@ -1,0 +1,73 @@
+import signal
+
+from sibyl.engine.engine import Engine
+from sibyl.commons import TimeoutException
+
+
+class MiasmEngine(Engine):
+    """Engine based on Miasm"""
+
+    def __init__(self, machine, jit_engine):
+        jitter = machine.jitter(jit_engine)
+        jitter.set_breakpoint(0x1337beef, MiasmEngine._code_sentinelle)
+        self.jitter = jitter
+
+        # Signal handling
+        #
+        # Due to Python signal handling implementation, signals aren't handled
+        # nor passed to Jitted code in case of registration with signal API
+        if jit_engine == "python":
+            signal.signal(signal.SIGALRM, MiasmEngine._timeout)
+        elif jit_engine in ["llvm", "tcc", "gcc"]:
+            self.jitter.vm.set_alarm()
+        else:
+            raise ValueError("Unknown engine: %s" % jit_engine)
+
+        super(MiasmEngine, self).__init__(machine)
+
+
+    @staticmethod
+    def _code_sentinelle(jitter):
+        jitter.run = False
+        jitter.pc = 0
+        return True
+
+    @staticmethod
+    def _timeout(signum, frame):
+        raise TimeoutException()
+
+    def run(self, address, timeout_seconds):
+        self.jitter.init_run(address)
+
+        try:
+            signal.alarm(timeout_seconds)
+            self.jitter.continue_run()
+        except (AssertionError, RuntimeError, ValueError,
+                KeyError, IndexError, TimeoutException) as _:
+            return False
+        except Exception as error:
+            self.logger.exception(error)
+            return False
+        finally:
+            signal.alarm(0)
+
+        return True
+
+    def restore_snapshot(self, memory=True):
+        # Restore memory
+        if memory:
+            self.jitter.vm.reset_memory_page_pool()
+            self.jitter.vm.reset_code_bloc_pool()
+            for addr, metadata in self.vm_mem.iteritems():
+                self.jitter.vm.add_memory_page(addr,
+                                               metadata["access"],
+                                               metadata["data"])
+
+        # Restore registers
+        self.jitter.cpu.init_regs()
+        self.jitter.cpu.set_gpreg(self.vm_regs)
+
+        # Reset intern elements
+        self.jitter.vm.set_exception(0)
+        self.jitter.cpu.set_exception(0)
+        self.jitter.bs._atomic_mode = False

--- a/sibyl/engine/qemu.py
+++ b/sibyl/engine/qemu.py
@@ -82,10 +82,11 @@ class UcWrapJitter(object):
         try:
             self.mu.emu_start(pc, END_ADDR,
                               timeout_seconds * unicorn.UC_SECOND_SCALE)
-        except Exception as e:
-            self.mu.emu_stop()
+        except unicorn.UcError as e:
             if getattr(self.cpu, self.ira.pc.name) != END_ADDR:
                 raise UnexpectedStopException()
+        finally:
+            self.mu.emu_stop()
 
     def verbose_mode(self):
         self.mu.hook_add(unicorn.UC_HOOK_MEM_READ_UNMAPPED, self.hook_mem_invalid)

--- a/sibyl/engine/qemu.py
+++ b/sibyl/engine/qemu.py
@@ -238,10 +238,10 @@ class UcWrapCPU_x86_32(UcWrapCPU):
     pc_reg_value = UC_X86_REG_EIP
 
 
-class UcWrapCPU_arm(UcWrapCPU):
+class UcWrapCPU_arml(UcWrapCPU):
 
     uc_arch = unicorn.UC_ARCH_ARM
-    uc_mode = unicorn.UC_MODE_ARM
+    uc_mode = unicorn.UC_MODE_ARM + unicorn.UC_MODE_LITTLE_ENDIAN
     regs = {'CPSR': UC_ARM_REG_CPSR, 'SPSR': UC_ARM_REG_SPSR,
             'R4': UC_ARM_REG_R4, 'R5': UC_ARM_REG_R5, 'R6': UC_ARM_REG_R6,
             'R7': UC_ARM_REG_R7, 'R0': UC_ARM_REG_R0, 'R1': UC_ARM_REG_R1,
@@ -255,5 +255,11 @@ class UcWrapCPU_arm(UcWrapCPU):
     pc_reg_value = UC_ARM_REG_PC
 
 
+class UcWrapCPU_armb(UcWrapCPU_arml):
+
+    uc_mode = unicorn.UC_MODE_ARM + unicorn.UC_MODE_BIG_ENDIAN
+
+
 UcWrapCPU_x86_32.register("x86", 32)
-UcWrapCPU_arm.register("arm", "l")
+UcWrapCPU_arml.register("arm", "l")
+UcWrapCPU_armb.register("arm", "b")

--- a/sibyl/engine/qemu.py
+++ b/sibyl/engine/qemu.py
@@ -7,6 +7,8 @@ except ImportError:
     unicorn = None
 
 from sibyl.engine.engine import Engine
+from sibyl.commons import END_ADDR
+
 
 class UnexpectedStopException(Exception):
     """Exception to be called on timeouts"""
@@ -68,11 +70,11 @@ class UcWrapJitter(object):
 
     def run(self, pc, timeout_seconds=1):
         try:
-            self.mu.emu_start(pc, 0x1337beef,
+            self.mu.emu_start(pc, END_ADDR,
                               timeout_seconds * unicorn.UC_SECOND_SCALE)
         except Exception as e:
             self.mu.emu_stop()
-            if self.cpu.EIP != 0x1337beef:
+            if self.cpu.EIP != END_ADDR:
                 raise UnexpectedStopException()
 
     def verbose_mode(self):

--- a/sibyl/engine/qemu.py
+++ b/sibyl/engine/qemu.py
@@ -3,6 +3,7 @@ from miasm2.jitter.csts import PAGE_READ, PAGE_WRITE
 try:
     import unicorn
     from unicorn.x86_const import *
+    from unicorn.arm_const import *
 except ImportError:
     unicorn = None
 
@@ -231,8 +232,28 @@ class UcWrapCPU_x86_32(UcWrapCPU):
     uc_mode = unicorn.UC_MODE_32
     regs = {"EAX": UC_X86_REG_EAX, "EBX": UC_X86_REG_EBX, "ECX": UC_X86_REG_ECX,
             "EDX": UC_X86_REG_EDX, "ESI": UC_X86_REG_ESI, "EDI": UC_X86_REG_EDI,
-            "EBP": UC_X86_REG_EBP, "ESP": UC_X86_REG_ESP}
+            "EBP": UC_X86_REG_EBP, "ESP": UC_X86_REG_ESP,
+    }
     pc_reg_name = "EIP"
     pc_reg_value = UC_X86_REG_EIP
 
+
+class UcWrapCPU_arm(UcWrapCPU):
+
+    uc_arch = unicorn.UC_ARCH_ARM
+    uc_mode = unicorn.UC_MODE_ARM
+    regs = {'CPSR': UC_ARM_REG_CPSR, 'SPSR': UC_ARM_REG_SPSR,
+            'R4': UC_ARM_REG_R4, 'R5': UC_ARM_REG_R5, 'R6': UC_ARM_REG_R6,
+            'R7': UC_ARM_REG_R7, 'R0': UC_ARM_REG_R0, 'R1': UC_ARM_REG_R1,
+            'R2': UC_ARM_REG_R2, 'R3': UC_ARM_REG_R3, 'R8': UC_ARM_REG_R8,
+            'R9': UC_ARM_REG_R9, 'R14': UC_ARM_REG_R14, 'R15': UC_ARM_REG_R15,
+            'R12': UC_ARM_REG_R12, 'R13': UC_ARM_REG_R13, 'R10': UC_ARM_REG_R10,
+            'R11': UC_ARM_REG_R11, 'SP': UC_ARM_REG_SP, 'SL': UC_ARM_REG_SL,
+            'SB': UC_ARM_REG_SB, 'LR': UC_ARM_REG_LR,
+    }
+    pc_reg_name = "PC"
+    pc_reg_value = UC_ARM_REG_PC
+
+
 UcWrapCPU_x86_32.register("x86", 32)
+UcWrapCPU_arm.register("arm", "l")

--- a/sibyl/engine/qemu.py
+++ b/sibyl/engine/qemu.py
@@ -1,0 +1,203 @@
+from miasm2.core.utils import pck32
+from miasm2.jitter.csts import PAGE_READ, PAGE_WRITE
+try:
+    import unicorn
+    from unicorn.x86_const import *
+except ImportError:
+    unicorn = None
+
+from sibyl.engine.engine import Engine
+
+class UnexpectedStopException(Exception):
+    """Exception to be called on timeouts"""
+    pass
+
+class QEMUEngine(Engine):
+    """Engine based on QEMU, using unicorn as a wrapper"""
+
+    def __init__(self, machine):
+        if unicorn is None:
+            raise ImportError("QEMU engine unavailable: 'unicorn' import error")
+
+        self.jitter = UcWrapJitter()
+        super(QEMUEngine, self).__init__(machine)
+
+
+    def run(self, address, timeout_seconds):
+        try:
+            self.jitter.run(address, timeout_seconds)
+        except UnexpectedStopException as _:
+            return False
+        except Exception as error:
+            self.logger.exception(error)
+            return False
+
+        return True
+
+    def prepare_run(self):
+        # XXX HACK: Avoid a slow down of unicorn (apparently to too many
+        # threads...)
+        self.jitter.renew()
+
+    def restore_snapshot(self, memory=True):
+        # Restore VM
+        if memory:
+            self.jitter.vm.restore_mem_state(self.vm_mem)
+
+        # Restore registers
+        self.jitter.cpu.set_gpreg(self.vm_regs)
+
+
+class UcWrapJitter(object):
+
+    def __init__(self):
+        self.renew()
+
+    def renew(self):
+        self.mu = unicorn.Uc(unicorn.UC_ARCH_X86, unicorn.UC_MODE_32)
+        self.vm = UcWrapVM(self.mu)
+        self.cpu = UcWrapCPU(self.mu)
+
+    def init_stack(self):
+        self.vm.add_memory_page(0x1230000, PAGE_WRITE | PAGE_READ, "\x00" * 0x10000, "Stack")
+        self.cpu.ESP = 0x1230000 + 0x10000
+
+    def push_uint32_t(self, value):
+        self.cpu.ESP -= 32 / 8
+        self.vm.set_mem(self.cpu.ESP, pck32(value))
+
+    def run(self, pc, timeout_seconds=1):
+        try:
+            self.mu.emu_start(pc, 0x1337beef,
+                              timeout_seconds * unicorn.UC_SECOND_SCALE)
+        except Exception as e:
+            self.mu.emu_stop()
+            if self.cpu.EIP != 0x1337beef:
+                raise UnexpectedStopException()
+
+    def verbose_mode(self):
+        self.mu.hook_add(unicorn.UC_HOOK_MEM_READ_UNMAPPED, self.hook_mem_invalid)
+        self.mu.hook_add(unicorn.UC_HOOK_CODE, self.hook_code)
+
+    @staticmethod
+    def hook_code(uc, address, size, user_data):
+        print(">>> Tracing instruction at 0x%x, instruction size = %u" %(address, size))
+        return True
+
+    @staticmethod
+    def hook_mem_invalid(uc, access, address, size, value, user_data):
+        self.logger.error("Invalid memory access at %s", hex(address))
+        return False
+
+
+class UcWrapVM(object):
+
+    def __init__(self, mu):
+        self.mem_page = []
+        self.mu = mu
+
+    def add_memory_page(self, addr, access, item_str, name=""):
+        size = len(item_str)
+        size = (size + 0xfff) & ~0xfff
+
+        for page in self.mem_page:
+            if page["addr"] <= addr < page["addr"] + page["size"]:
+                self.set_mem(addr, item_str)
+                return
+
+        self.mem_page.append({"addr": addr,
+                              "size": size,
+                              "name": name,
+                              "access": access,
+        })
+
+        self.mu.mem_map(addr, size)
+        self.set_mem(addr, item_str)
+
+    def get_mem(self, addr, size):
+        return str(self.mu.mem_read(addr, size))
+
+    def set_mem(self, addr, content):
+        self.mu.mem_write(addr, str(content))
+
+    def get_all_memory(self):
+        dico = {}
+        for page in self.mem_page:
+            data = self.get_mem(page["addr"], page["size"])
+            dico[page["addr"]] = {"access": page["access"],
+                                  "size": len(data),
+                                  "data": data}
+
+        return dico
+
+    def restore_mem_state(self, mem_state):
+        """Restore the memory state according to mem_state
+        Optimisation: only consider memory unwrittable"""
+        new_mem_page = []
+        addrs = set()
+
+        for page in self.mem_page:
+            if page["addr"] not in mem_state:
+                # Remove additionnal pages
+                self.mu.mem_unmap(page["addr"], page["size"])
+            else:
+                # Rewrite pages content
+                if page["access"] & PAGE_WRITE:
+                    self.set_mem(page["addr"], mem_state[page["addr"]]["data"])
+                new_mem_page.append(page)
+                addrs.add(page["addr"])
+
+        for addr, page in mem_state.iteritems():
+            # Add missing pages
+            if addr not in addrs:
+                self.mu.mem_map(addr, page["size"])
+                self.set_mem(addr, page["data"])
+                new_mem_page.append({"addr": addr,
+                                     "size": page["size"],
+                                     "name": "",
+                                     "access": page["access"]})
+        self.mem_page = new_mem_page
+
+
+class UcWrapCPU(object):
+
+    regs = [UC_X86_REG_EAX, UC_X86_REG_EBX, UC_X86_REG_ECX, UC_X86_REG_EDX,
+            UC_X86_REG_ESI, UC_X86_REG_EDI, UC_X86_REG_EBP, UC_X86_REG_ESP]
+    def __init__(self, mu):
+        self.mu = mu
+
+    def init_regs(self):
+        for reg in self.regs:
+            self.mu.reg_write(reg, 0)
+
+    def __setattr__(self, name, value):
+        if name in ["mu"]:
+            super(UcWrapCPU, self).__setattr__(name, value)
+        elif name == "ESP":
+            self.mu.reg_write(UC_X86_REG_ESP, value)
+        elif name == "EIP":
+            self.mu.reg_write(UC_X86_REG_EIP, value)
+        else:
+            fds
+
+    def __getattr__(self, name):
+        if name == "ESP":
+            return self.mu.reg_read(UC_X86_REG_ESP)
+        if name == "EIP":
+            return self.mu.reg_read(UC_X86_REG_EIP)
+        if name == "EAX":
+            return self.mu.reg_read(UC_X86_REG_EAX)
+        else:
+            print name
+            super(UcWrapCPU, self).__getattr__(name)
+
+    def get_gpreg(self):
+        return {i: self.mu.reg_read(v) for i, v in enumerate(self.regs)}
+
+    def set_gpreg(self, values):
+        for i, v in enumerate(self.regs):
+            self.mu.reg_write(v, values[i])
+
+    def set_exception(self, value):
+        pass
+

--- a/sibyl/engine/qemu.py
+++ b/sibyl/engine/qemu.py
@@ -4,6 +4,7 @@ try:
     import unicorn
     from unicorn.x86_const import *
     from unicorn.arm_const import *
+    from unicorn.mips_const import *
 except ImportError:
     unicorn = None
 
@@ -260,6 +261,86 @@ class UcWrapCPU_armb(UcWrapCPU_arml):
     uc_mode = unicorn.UC_MODE_ARM + unicorn.UC_MODE_BIG_ENDIAN
 
 
+class UcWrapCPU_mips32l(UcWrapCPU):
+
+    uc_arch = unicorn.UC_ARCH_MIPS
+    uc_mode = unicorn.UC_MODE_MIPS32 + unicorn.UC_MODE_LITTLE_ENDIAN
+    regs = {'CPR0_0': UC_MIPS_REG_0, 'CPR0_1': UC_MIPS_REG_1,
+            'CPR0_10': UC_MIPS_REG_10, 'CPR0_11': UC_MIPS_REG_11,
+            'CPR0_12': UC_MIPS_REG_12, 'CPR0_13': UC_MIPS_REG_13,
+            'CPR0_14': UC_MIPS_REG_14, 'CPR0_15': UC_MIPS_REG_15,
+            'CPR0_16': UC_MIPS_REG_16, 'CPR0_17': UC_MIPS_REG_17,
+            'CPR0_18': UC_MIPS_REG_18, 'CPR0_19': UC_MIPS_REG_19,
+            'CPR0_2': UC_MIPS_REG_2, 'CPR0_20': UC_MIPS_REG_20,
+            'CPR0_21': UC_MIPS_REG_21, 'CPR0_22': UC_MIPS_REG_22,
+            'CPR0_23': UC_MIPS_REG_23, 'CPR0_24': UC_MIPS_REG_24,
+            'CPR0_25': UC_MIPS_REG_25, 'CPR0_26': UC_MIPS_REG_26,
+            'CPR0_27': UC_MIPS_REG_27, 'CPR0_28': UC_MIPS_REG_28,
+            'CPR0_29': UC_MIPS_REG_29, 'CPR0_3': UC_MIPS_REG_3,
+            'CPR0_30': UC_MIPS_REG_30, 'CPR0_31': UC_MIPS_REG_31,
+            'CPR0_4': UC_MIPS_REG_4, 'CPR0_5': UC_MIPS_REG_5,
+            'CPR0_6': UC_MIPS_REG_6, 'CPR0_7': UC_MIPS_REG_7,
+            'CPR0_8': UC_MIPS_REG_8, 'CPR0_9': UC_MIPS_REG_9,
+            'A0': UC_MIPS_REG_A0, 'A1': UC_MIPS_REG_A1, 'A2': UC_MIPS_REG_A2,
+            'A3': UC_MIPS_REG_A3, 'CC0': UC_MIPS_REG_CC0, 'CC1': UC_MIPS_REG_CC1,
+            'CC2': UC_MIPS_REG_CC2, 'CC3': UC_MIPS_REG_CC3,
+            'CC4': UC_MIPS_REG_CC4, 'CC5': UC_MIPS_REG_CC5,
+            'CC6': UC_MIPS_REG_CC6, 'CC7': UC_MIPS_REG_CC7,
+            'F0': UC_MIPS_REG_F0, 'F1': UC_MIPS_REG_F1, 'F10': UC_MIPS_REG_F10,
+            'F11': UC_MIPS_REG_F11, 'F12': UC_MIPS_REG_F12,
+            'F13': UC_MIPS_REG_F13, 'F14': UC_MIPS_REG_F14,
+            'F15': UC_MIPS_REG_F15, 'F16': UC_MIPS_REG_F16,
+            'F17': UC_MIPS_REG_F17, 'F18': UC_MIPS_REG_F18,
+            'F19': UC_MIPS_REG_F19, 'F2': UC_MIPS_REG_F2,
+            'F20': UC_MIPS_REG_F20, 'F21': UC_MIPS_REG_F21,
+            'F22': UC_MIPS_REG_F22, 'F23': UC_MIPS_REG_F23,
+            'F24': UC_MIPS_REG_F24, 'F25': UC_MIPS_REG_F25,
+            'F26': UC_MIPS_REG_F26, 'F27': UC_MIPS_REG_F27,
+            'F28': UC_MIPS_REG_F28, 'F29': UC_MIPS_REG_F29,
+            'F3': UC_MIPS_REG_F3, 'F30': UC_MIPS_REG_F30,
+            'F31': UC_MIPS_REG_F31, 'F4': UC_MIPS_REG_F4, 'F5': UC_MIPS_REG_F5,
+            'F6': UC_MIPS_REG_F6, 'F7': UC_MIPS_REG_F7, 'F8': UC_MIPS_REG_F8,
+            'F9': UC_MIPS_REG_F9, 'FCC0': UC_MIPS_REG_FCC0,
+            'FCC1': UC_MIPS_REG_FCC1, 'FCC2': UC_MIPS_REG_FCC2,
+            'FCC3': UC_MIPS_REG_FCC3, 'FCC4': UC_MIPS_REG_FCC4,
+            'FCC5': UC_MIPS_REG_FCC5, 'FCC6': UC_MIPS_REG_FCC6,
+            'FCC7': UC_MIPS_REG_FCC7, 'FP': UC_MIPS_REG_FP,
+            'GP': UC_MIPS_REG_GP, 'R_HI': UC_MIPS_REG_HI, 'K0': UC_MIPS_REG_K0,
+            'K1': UC_MIPS_REG_K1, 'R_LO': UC_MIPS_REG_LO, 'RA': UC_MIPS_REG_RA,
+            'S0': UC_MIPS_REG_S0, 'S1': UC_MIPS_REG_S1, 'S2': UC_MIPS_REG_S2,
+            'S3': UC_MIPS_REG_S3, 'S4': UC_MIPS_REG_S4, 'S5': UC_MIPS_REG_S5,
+            'S6': UC_MIPS_REG_S6, 'S7': UC_MIPS_REG_S7, 'S8': UC_MIPS_REG_S8,
+            'SP': UC_MIPS_REG_SP, 'T0': UC_MIPS_REG_T0, 'T1': UC_MIPS_REG_T1,
+            'T2': UC_MIPS_REG_T2, 'T3': UC_MIPS_REG_T3, 'T4': UC_MIPS_REG_T4,
+            'T5': UC_MIPS_REG_T5, 'T6': UC_MIPS_REG_T6, 'T7': UC_MIPS_REG_T7,
+            'T8': UC_MIPS_REG_T8, 'T9': UC_MIPS_REG_T9, 'V0': UC_MIPS_REG_V0,
+            'V1': UC_MIPS_REG_V1, 'W0': UC_MIPS_REG_W0, 'W1': UC_MIPS_REG_W1,
+            'W10': UC_MIPS_REG_W10, 'W11': UC_MIPS_REG_W11,
+            'W12': UC_MIPS_REG_W12, 'W13': UC_MIPS_REG_W13,
+            'W14': UC_MIPS_REG_W14, 'W15': UC_MIPS_REG_W15,
+            'W16': UC_MIPS_REG_W16, 'W17': UC_MIPS_REG_W17,
+            'W18': UC_MIPS_REG_W18, 'W19': UC_MIPS_REG_W19,
+            'W2': UC_MIPS_REG_W2, 'W20': UC_MIPS_REG_W20,
+            'W21': UC_MIPS_REG_W21, 'W22': UC_MIPS_REG_W22,
+            'W23': UC_MIPS_REG_W23, 'W24': UC_MIPS_REG_W24,
+            'W25': UC_MIPS_REG_W25, 'W26': UC_MIPS_REG_W26,
+            'W27': UC_MIPS_REG_W27, 'W28': UC_MIPS_REG_W28,
+            'W29': UC_MIPS_REG_W29, 'W3': UC_MIPS_REG_W3,
+            'W30': UC_MIPS_REG_W30, 'W31': UC_MIPS_REG_W31,
+            'W4': UC_MIPS_REG_W4, 'W5': UC_MIPS_REG_W5, 'W6': UC_MIPS_REG_W6,
+            'W7': UC_MIPS_REG_W7, 'W8': UC_MIPS_REG_W8, 'W9': UC_MIPS_REG_W9,
+    }
+    pc_reg_name = "PC"
+    pc_reg_value = UC_MIPS_REG_PC
+
+
+class UcWrapCPU_mips32b(UcWrapCPU):
+
+    uc_mode = unicorn.UC_MODE_MIPS32 + unicorn.UC_MODE_BIG_ENDIAN
+
+
 UcWrapCPU_x86_32.register("x86", 32)
 UcWrapCPU_arml.register("arm", "l")
 UcWrapCPU_armb.register("arm", "b")
+UcWrapCPU_mips32l.register("mips32", "l")
+UcWrapCPU_mips32b.register("mips32", "b")

--- a/sibyl/testlauncher.py
+++ b/sibyl/testlauncher.py
@@ -22,7 +22,7 @@ import signal
 import logging
 from miasm2.analysis.binary import Container
 
-from sibyl.commons import init_logger, TimeoutException
+from sibyl.commons import init_logger, TimeoutException, END_ADDR
 from sibyl.engine import QEMUEngine, MiasmEngine
 
 class TestLauncher(object):
@@ -87,7 +87,7 @@ class TestLauncher(object):
 
             # Prepare VM
             init(test)
-            self.abi.prepare_call(ret_addr=0x1337beef)
+            self.abi.prepare_call(ret_addr=END_ADDR)
 
             # Run code
             status = self.engine.run(address, timeout_seconds)

--- a/sibyl/testlauncher.py
+++ b/sibyl/testlauncher.py
@@ -22,42 +22,29 @@ import signal
 import logging
 from miasm2.analysis.binary import Container
 
-
-class TimeoutException(Exception):
-    """Exception to be called on timeouts"""
-    pass
-
+from sibyl.commons import init_logger, TimeoutException
+from sibyl.engine import QEMUEngine, MiasmEngine
 
 class TestLauncher(object):
     "Launch tests for a function and report matching candidates"
 
-    def __init__(self, filename, machine, abicls, tests_cls, jitter_engine,
+    def __init__(self, filename, machine, abicls, tests_cls, engine_name,
                  map_addr=0):
 
         # Logging facilities
-        self.init_logger()
+        self.logger = init_logger("testlauncher")
 
         # Prepare JiT engine
         self.machine = machine
-        self.init_jit(jitter_engine)
+        self.init_engine(engine_name)
 
         # Init and snapshot VM
         self.load_vm(filename, map_addr)
-        self.save_vm()
+        self.snapshot = self.engine.take_snapshot()
 
         # Init tests
         self.init_abi(abicls)
         self.initialize_tests(tests_cls)
-
-    def init_logger(self):
-        self.logger = logging.getLogger("testlauncher")
-
-        console_handler = logging.StreamHandler()
-        log_format = "%(levelname)-5s: %(message)s"
-        console_handler.setFormatter(logging.Formatter(log_format))
-        self.logger.addHandler(console_handler)
-
-        self.logger.setLevel(logging.ERROR)
 
     def initialize_tests(self, tests_cls):
         tests = []
@@ -71,58 +58,16 @@ class TestLauncher(object):
         self.jitter.cpu.init_regs()
         self.jitter.init_stack()
 
-    def save_vm(self):
-        self.vm_mem = self.jitter.vm.get_all_memory()
-        self.vm_regs = self.jitter.cpu.get_gpreg()
-
-    def restore_vm(self, reset_mem=True):
-        # Restore memory
-        if reset_mem:
-            self.jitter.vm.reset_memory_page_pool()
-            self.jitter.vm.reset_code_bloc_pool()
-            for addr, metadata in self.vm_mem.iteritems():
-                self.jitter.vm.add_memory_page(addr,
-                                                  metadata["access"],
-                                                  metadata["data"])
-
-        # Restore registers
-        self.jitter.cpu.init_regs()
-        self.jitter.cpu.set_gpreg(self.vm_regs)
-
-    @staticmethod
-    def _code_sentinelle(jitter):
-        jitter.run = False
-        jitter.pc = 0
-        return True
-
-    @staticmethod
-    def _timeout(signum, frame):
-        raise TimeoutException()
-
-    def init_jit(self, jit_engine):
-        jitter = self.machine.jitter(jit_engine)
-        jitter.set_breakpoint(0x1337beef, TestLauncher._code_sentinelle)
-        self.jitter = jitter
-
-        # Signal handling
-        #
-        # Due to Python signal handling implementation, signals aren't handled
-        # nor passed to Jitted code in case of registration with signal API
-        if jit_engine == "python":
-            signal.signal(signal.SIGALRM, TestLauncher._timeout)
-        elif jit_engine in ["llvm", "tcc", "gcc"]:
-            self.jitter.vm.set_alarm()
+    def init_engine(self, engine_name):
+        if engine_name == "qemu":
+            self.engine = QEMUEngine(self.machine)
+        else:
+            self.engine = MiasmEngine(self.machine, engine_name)
+        self.jitter = self.engine.jitter
 
     def init_abi(self, abicls):
         ira = self.machine.ira()
         self.abi = abicls(self.jitter, ira)
-
-    def reset_state(self, reset_mem=True):
-        self.restore_vm(reset_mem)
-        self.jitter.vm.set_exception(0)
-        self.jitter.cpu.set_exception(0)
-        self.jitter.bs._atomic_mode = False
-        self.abi.reset()
 
     def launch_tests(self, test, address, timeout_seconds=0):
         # Variables to remind between two "launch_test"
@@ -135,27 +80,21 @@ class TestLauncher(object):
         def launch_test(init, check):
             """Launch a test associated with @init, @check"""
 
-            # Reset VM
-            self.reset_state(reset_mem=self._temp_reset_mem)
+            # Reset state
+            self.engine.restore_snapshot(memory=self._temp_reset_mem)
+            self.abi.reset()
             test.reset()
 
             # Prepare VM
             init(test)
             self.abi.prepare_call(ret_addr=0x1337beef)
-            self.jitter.init_run(address)
 
             # Run code
-            try:
-                signal.alarm(timeout_seconds)
-                self.jitter.continue_run()
-            except (AssertionError, RuntimeError, ValueError,
-                    KeyError, IndexError, TimeoutException) as _:
+            status = self.engine.run(address, timeout_seconds)
+            if not status:
+                # Early quit
+                self._temp_reset_mem = True
                 return False
-            except Exception as error:
-                self.logger.exception(error)
-                return False
-            finally:
-                signal.alarm(0)
 
             # Check result
             to_ret = check(test)
@@ -177,6 +116,7 @@ class TestLauncher(object):
         self.logger.info("Launch tests (%d available functions)" % (nb_tests))
         starttime = time.time()
 
+        self.engine.prepare_run()
         for test in self.tests:
             self.launch_tests(test, address, *args, **kwargs)
 


### PR DESCRIPTION
This PR adds the support of QEMU as emulator (through Unicorn). It ends with better performance (from x2 to x10 depending on the architecture on my tests), and a better support of architecture diversity (for instance, SSE is not yet fully supported in Miasm, and then some function can not be recognized).

To use it, install `unicorn` Python binding and use `-j qemu`.

Regarding the implementation, this PR introduces the notion of `engine`, which abstract the emulation part. For now, available engines are Miasm and QEMU.