### PR TITLE
Fix abi

### DIFF
--- a/sibyl/abi/abi.py
+++ b/sibyl/abi/abi.py
@@ -51,7 +51,6 @@ class ABIRegsStack(ABI):
 
     regs_mapping = None # Register mapping (list of str)
     args = None         # order => element
-    RTL = False         # RightToLeft arguments pushing
 
     def __init__(self, *args, **kwargs):
         super(ABIRegsStack, self).__init__(*args, **kwargs)
@@ -72,10 +71,8 @@ class ABIRegsStack(ABI):
     def prepare_call(self, ret_addr):
         # Get args
         numbers = sorted(self.args.keys())
-        if self.RTL:
-            numbers = numbers[::-1]
 
-        for i, key in enumerate(numbers):
+        for i, key in reversed(list(enumerate(numbers))):
             element = self.args[key]
 
             if i < len(self.regs_mapping):

--- a/sibyl/abi/abi.py
+++ b/sibyl/abi/abi.py
@@ -58,7 +58,7 @@ class ABIRegsStack(ABI):
         self.args = {}
 
     def add_arg(self, number, element):
-        if isinstance(element, int):
+        if isinstance(element, (int, long)):
             self.args[number] = element
         else:
             raise NotImplementedError()

--- a/sibyl/abi/x86.py
+++ b/sibyl/abi/x86.py
@@ -42,7 +42,7 @@ class ABIFastCall_x86_32(ABIRegsStack_x86):
         self.jitter.push_uint32_t(element)
 
 
-class ABI_AMD64(ABIRegsStack_x86):
+class ABI_AMD64_SYSTEMV(ABIRegsStack_x86):
 
     regs_mapping = ["RDI", "RSI", "RDX", "RCX", "R8", "R9"]
     arch = ["x86_64"]
@@ -51,4 +51,19 @@ class ABI_AMD64(ABIRegsStack_x86):
         self.jitter.push_uint64_t(element)
 
 
-ABIS = [ABIStdCall_x86_32, ABIFastCall_x86_32, ABI_AMD64]
+class ABI_AMD64_MS(ABIRegsStack_x86):
+
+    regs_mapping = ["RCX", "RDX", "R8", "R9"]
+    arch = ["x86_64"]
+
+    def vm_push(self, element):
+        self.jitter.push_uint64_t(element)
+
+    def set_ret(self, ret_addr):
+        # Shadow stack reservation: 0x20 bytes
+        for i in xrange(4):
+            self.vm_push(0)
+        super(ABI_AMD64_MS, self).set_ret(ret_addr)
+
+
+ABIS = [ABIStdCall_x86_32, ABIFastCall_x86_32, ABI_AMD64_SYSTEMV, ABI_AMD64_MS]

--- a/sibyl/abi/x86.py
+++ b/sibyl/abi/x86.py
@@ -27,7 +27,6 @@ class ABIRegsStack_x86(abi.ABIRegsStack):
 class ABIStdCall_x86_32(ABIRegsStack_x86):
 
     regs_mapping = [] # Stack only
-    RTL = True
     arch = ["x86_32"]
 
     def vm_push(self, element):

--- a/sibyl/actions/learn.py
+++ b/sibyl/actions/learn.py
@@ -7,7 +7,7 @@ from sibyl.actions.action import Action
 from sibyl.learn.tracer import AVAILABLE_TRACER
 from sibyl.learn.generator import AVAILABLE_GENERATOR
 from sibyl.learn.learn import TestCreator
-from sibyl.abi.x86 import ABI_AMD64
+from sibyl.abi.x86 import ABI_AMD64_SYSTEMV
 
 
 class ActionLearn(Action):
@@ -41,8 +41,8 @@ class ActionLearn(Action):
     ]
 
     def run(self):
-        # Currently only AMD64 ABI is supported by the learning module
-        abi = ABI_AMD64
+        # Currently only AMD64 SYSTEMV ABI is supported by the learning module
+        abi = ABI_AMD64_SYSTEMV
 
         # Currently only x86_64 is supported by the learning module
         machine = "x86_64"


### PR DESCRIPTION
The RTL option is broken:
 - if not used, stack argument are pushed in bad order for ABI using reg/stack
 - if used, ABI using registers argument will be reversed.

To confirm stack arguments order, on linux amd64:
func(1, 2, 3, 4, 5, 6, 7, 8);
generates:
push    8
push    7
mov     r9d, 6
mov     r8d, 5
mov     ecx, 4
mov     edx, 3
mov     esi, 2
mov     edi, 1
call    func

Rename `ABI_AMD64` to `ABI_AMD64_SYSTEMV`
Add `ABI_AMD64_MS`