### PR TITLE
Lazy import for actions

### DIFF
--- a/bin/sibyl
+++ b/bin/sibyl
@@ -49,6 +49,7 @@ if __name__ == "__main__":
         if len(guessed) == 0:
             print "Unknown action: %s" % action
         else:
-            print "Ambiguous action: %s" % " ".join(guessed)
+            print "Ambiguous action: %s" % " ".join(guess.name
+                                                    for guess in guessed)
         exit(-1)
 

--- a/bin/sibyl
+++ b/bin/sibyl
@@ -20,7 +20,7 @@
 import sys
 
 from sibyl.commons import print_table
-from sibyl.actions import ACTIONS
+from sibyl.actions import ACTIONS, load_action
 
 if __name__ == "__main__":
 
@@ -28,9 +28,9 @@ if __name__ == "__main__":
         print "Usage: %s [action]\n" % sys.argv[0]
         print "Actions:"
         # Sort actions by name and print them
-        actions = [(action._name_, action._desc_)
+        actions = [(action.name, action.desc)
                    for action in sorted(ACTIONS,
-                                        key=lambda action: action._name_)]
+                                        key=lambda action: action.name)]
         print_table(actions,
                     title=False,
                     separator=" ",
@@ -40,10 +40,10 @@ if __name__ == "__main__":
     action = sys.argv[1]
 
     # Try to guess action
-    guessed = [act for act in ACTIONS if act._name_.startswith(action)]
+    guessed = [act for act in ACTIONS if act.name.startswith(action)]
     if len(guessed) == 1:
         # Action found, redirect to it
-        guessed[0](sys.argv[2:])
+        load_action(guessed[0], sys.argv[2:])
     else:
         # Action not found
         if len(guessed) == 0:

--- a/sibyl/actions/__init__.py
+++ b/sibyl/actions/__init__.py
@@ -15,14 +15,19 @@
 # along with Sibyl. If not, see <http://www.gnu.org/licenses/>.
 "Sibyl actions implementations"
 
-from sibyl.actions.find import ActionFind
-from sibyl.actions.learn import ActionLearn
-from sibyl.actions.config import ActionConfig
-from sibyl.actions.func import ActionFunc
+from collections import namedtuple
+from importlib import import_module
 
+ActionDesc = namedtuple("ActionDesc", ["name", "desc", "module", "classname"])
 
-ACTIONS = (ActionFind,
-           ActionLearn,
-           ActionConfig,
-           ActionFunc,
-)
+ACTIONS = [
+    ActionDesc("config", "Configuration management", "config", "ActionConfig"),
+    ActionDesc("find", "Function guesser", "find", "ActionFind"),
+    ActionDesc("func", "Function discovering", "func", "ActionFunc"),
+    ActionDesc("learn", "Learn a new function", "learn", "ActionLearn"),
+]
+
+def load_action(actiondesc, args):
+    "Load the action associated to @actiondesc with arguments @args"
+    mod = import_module(".%s" % actiondesc.module, "sibyl.actions")
+    return getattr(mod, actiondesc.classname)(args)


### PR DESCRIPTION
Avoid an unnecessary slow time at `sibyl` execution + mitigate errors propagation between sub-actions