### PR TITLE
Fix/ret struct

### DIFF
--- a/sibyl/learn/findref.py
+++ b/sibyl/learn/findref.py
@@ -177,7 +177,7 @@ class ExtractRef(object):
 
         cur_addr = jitter.pc
         self.logger.debug("Current address: %s", hex(cur_addr))
-        if cur_addr == 0x1337BEEF:
+        if cur_addr == 0x1337BEEF or cur_addr == self.return_addr:
             # End reached
             if self.logger.isEnabledFor(logging.DEBUG):
                 print "In:"
@@ -205,7 +205,7 @@ class ExtractRef(object):
 
         return True
 
-    def prepare_symbexec(self, jitter):
+    def prepare_symbexec(self, jitter, return_addr):
         # Activate callback on each instr
         jitter.jit.set_options(max_exec_per_call=1, jit_maxline=1)
         #jitter.jit.log_mn = True
@@ -240,6 +240,9 @@ class ExtractRef(object):
 
         ## Save the initial state
         self.symbols_init = self.symb.symbols.copy()
+
+        ## Save the returning address
+        self.return_addr = return_addr
 
         # Inject argument
         # TODO
@@ -337,7 +340,7 @@ class ExtractRef(object):
 
         # Prepare the execution
         jitter.init_run(self.learned_addr)
-        self.prepare_symbexec(jitter)
+        self.prepare_symbexec(jitter, return_addr)
 
         # Run the execution
         try:

--- a/sibyl/learn/findref.py
+++ b/sibyl/learn/findref.py
@@ -283,12 +283,18 @@ class ExtractRef(object):
         memory_in = {}
         memory_out = {}
 
+        # Get the resulting symbolic value
+        # TODO use abi
+        output_value = self.symb.symbols[self.symb.ir_arch.arch.regs.RAX]
+
+        # Fill memory *out* (written)
         for expr in self.memories_write:
             # Eval the expression with the *output* state
             value = self.symb.eval_expr(expr)
             assert isinstance(value, m2_expr.ExprInt)
             memory_out[expr] = value
 
+        # Fill memory *in* (read)
         saved_symbols = self.symb.symbols
         self.symb.symbols = self.symbols_init
         for expr in self.memories_read:
@@ -304,8 +310,12 @@ class ExtractRef(object):
             print memory_in
             print "Out:"
             print memory_out
+            print "Final value:"
+            print output_value
+
         self.snapshot.memory_in = AssignBlock(memory_in)
         self.snapshot.memory_out = AssignBlock(memory_out)
+        self.snapshot.output_value = output_value
         self.snapshot.c_handler = self.c_handler
         self.snapshot.arguments_symbols = self.args_symbols
 

--- a/sibyl/test/test.py
+++ b/sibyl/test/test.py
@@ -302,10 +302,15 @@ class TestHeader(Test):
         return ret
 
     def field_addr(self, base, Clike, is_ptr=False):
-        base_expr = self.trad(base)
-        if is_ptr:
-            access_expr = self.trad(Clike)
-        else:
-            access_expr = self.trad("&(%s)" % Clike)
-        offset = int(expr_simp(access_expr - base_expr))
-        return offset
+        key = (base, Clike, is_ptr)
+        ret = self.cache_field_addr.get(key, None)
+        if ret is None:
+            base_expr = self.trad(base)
+            if is_ptr:
+                access_expr = self.trad(Clike)
+            else:
+                access_expr = self.trad("&(%s)" % Clike)
+            offset = int(expr_simp(access_expr - base_expr))
+            ret = offset
+            self.cache_field_addr[key] = ret
+        return ret

--- a/sibyl/test/test.py
+++ b/sibyl/test/test.py
@@ -301,8 +301,11 @@ class TestHeader(Test):
             self.cache_trad[Clike] = ret
         return ret
 
-    def field_addr(self, base, Clike):
+    def field_addr(self, base, Clike, is_ptr=False):
         base_expr = self.trad(base)
-        access_expr = self.trad("&(%s)" % Clike)
+        if is_ptr:
+            access_expr = self.trad(Clike)
+        else:
+            access_expr = self.trad("&(%s)" % Clike)
         offset = int(expr_simp(access_expr - base_expr))
         return offset

--- a/test/learn/run_tests.py
+++ b/test/learn/run_tests.py
@@ -14,9 +14,7 @@ from sibyl.config import config
 
 # Tests to fix
 unsupported = [
-    "my_strcpy",
     "numerous_arguments",
-    "deref_struct",
 ]
 
 def invoke_pin(filename, func_name, header_filename, cont):


### PR DESCRIPTION
Improves "Add regression tests for the learning module" and "Adds support for function returning a non-allocated pointer" from #27 

For instance, a function `elem* search(elem* list);` returning a pointer on the element in `list` matching certain criteria. As a consequence, the sample `deref_struct` and `strcpy` are now working.