### PR TITLE
Feature/trace pruning

### DIFF
--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -41,6 +41,10 @@ jit_engine = gcc,llvm,tcc,python
 [pin]
 root = $PIN_ROOT
 tracer = $SIBYL/ext/pin_tracer/pin_tracer.so
+
+[learn]
+prune_strategy = branch
+prune_keep = 2
 ```
 
 ### Section 'find'
@@ -88,6 +92,17 @@ If `pin` is already in the user's path, this parameter can be ignored.
 The `tracer` parameter is the path of the compiled version of the tracer
 `ext/pin_tracer/pin_tracer.cpp`, which will probably looks like
 `/path/to/sibyl/ext/pin_tracer/pin_tracer.so`.
+
+### Section 'learn'
+
+This section contains options relative to the `learn` action.
+
+The `prune_strategy` parameter indicates which strategy should be used to prune
+the obtained snapshots. Current supported values are `branch`, `keep`, `keepall`.
+
+The `prune_keep` value specifies the number of snapshot to keep per prunning.
+
+Please refer to the related documentation for more information.
 
 ### Configuration overview
 

--- a/ext/pin_tracer/pin_tracer.cpp
+++ b/ext/pin_tracer/pin_tracer.cpp
@@ -125,7 +125,6 @@ VOID DumpRegsO(VOID * ip, ADDRINT rax, ADDRINT rbx, ADDRINT rcx, ADDRINT rdx, AD
 			/* Log output registers */
 			instrument = 0;
 			check_fprintf_error(fprintf(trace,"O %lx %lx %lx %lx %lx %lx %lx %lx %lx %lx %lx %lx %lx %lx %lx %lx\n", rax, rbx, rcx, rdx, rsi, rdi, rbp, rsp, r8, r9, r10, r11, r12, r13, r14, r15));
-			exit(0);
 		}
 	}
 }

--- a/sibyl/actions/config.py
+++ b/sibyl/actions/config.py
@@ -75,6 +75,10 @@ class ActionConfig(Action):
         else:
             print "PIN tracer not found"
 
+        # Learn
+        print "Learn's pruning strategy: %s/%d" % (config.prune_strategy,
+                                                   config.prune_keep)
+
         # Tests
         print "Tests availables:"
         for name, tests in config.available_tests.iteritems():

--- a/sibyl/config.py
+++ b/sibyl/config.py
@@ -250,6 +250,7 @@ class Config(object):
         if strategy not in [
                 "branch",
                 "keepall",
+                "keep",
         ]:
             raise ValueError("Unknown strategy type: %s" % strategy)
         return strategy

--- a/sibyl/config.py
+++ b/sibyl/config.py
@@ -249,6 +249,7 @@ class Config(object):
         strategy = self.config["prune_strategy"]
         if strategy not in [
                 "branch",
+                "keepall",
         ]:
             raise ValueError("Unknown strategy type: %s" % strategy)
         return strategy

--- a/sibyl/config.py
+++ b/sibyl/config.py
@@ -27,6 +27,8 @@ default_config = {
     },
     "pin_root": "$PIN_ROOT",
     "pin_tracer": "$SIBYL/ext/pin_tracer/pin_tracer.so",
+    "prune_strategy": "branch",
+    "prune_keep": 2,
 }
 
 config_paths = [os.path.join(path, 'sibyl.conf')
@@ -110,6 +112,20 @@ class Config(object):
             if cparser.has_option("pin", "tracer"):
                 self.config["pin_tracer"] = cparser.get("pin", "tracer")
 
+        # Learning
+        #
+        # [learn]
+        if cparser.has_section("learn"):
+            # prune_strategy = branch
+            if cparser.has_option("learn", "prune_strategy"):
+                self.config["prune_strategy"] = cparser.get("learn",
+                                                            "prune_strategy")
+            # prune_keep = 2
+            if cparser.has_option("learn", "prune_keep"):
+                self.config["prune_keep"] = cparser.getint("learn",
+                                                           "prune_keep")
+
+
 
 
     def dump(self):
@@ -136,6 +152,12 @@ class Config(object):
         out.append("[pin]")
         out.append("root = %s" % self.config["pin_root"])
         out.append("tracer = %s" % self.config["pin_tracer"])
+
+        # Learn
+        out.append("")
+        out.append("[learn]")
+        out.append("prune_strategy = %s" % self.config["prune_strategy"])
+        out.append("prune_keep = %d" % self.config["prune_keep"])
 
         return out
 
@@ -220,6 +242,21 @@ class Config(object):
         It should be the compiled version of ext/pin_tracer/pin_tracer.cpp
         """
         return self.expandpath(self.config["pin_tracer"])
+
+    @property
+    def prune_strategy(self):
+        """Strategy used to prune while learning"""
+        strategy = self.config["prune_strategy"]
+        if strategy not in [
+                "branch",
+        ]:
+            raise ValueError("Unknown strategy type: %s" % strategy)
+        return strategy
+
+    @property
+    def prune_keep(self):
+        """Number of elements to keep for each pruning possibility"""
+        return self.config["prune_keep"]
 
 
 config = Config(default_config, config_paths)

--- a/sibyl/learn/learn.py
+++ b/sibyl/learn/learn.py
@@ -84,8 +84,11 @@ class TestCreator(object):
         elif config.prune_strategy == "keepall":
             # Do not remove any snapshot
             pass
+        elif config.prune_strategy == "keep":
+            # Remove all snapshot but one or a few (according to config)
+            to_remove = self.trace[config.prune_keep:]
         else:
-            raise ValueError("Unsupported strategy type: %s" % config.strategy)
+            raise ValueError("Unsupported strategy type: %s" % config.prune_strategy)
 
         # Actually removed elements
         for snapshot in to_remove:

--- a/sibyl/learn/learn.py
+++ b/sibyl/learn/learn.py
@@ -81,6 +81,9 @@ class TestCreator(object):
                     # occurences are already keeped
                     to_remove.append(snapshot)
                 already_keeped[path] = current + 1
+        elif config.prune_strategy == "keepall":
+            # Do not remove any snapshot
+            pass
         else:
             raise ValueError("Unsupported strategy type: %s" % config.strategy)
 


### PR DESCRIPTION
Support multiple strategy for trace pruning for release #27 .

Implemented strategy:
* `branch` : branch coverage
* `keepall` : do not prune
* `keep` : keep arbitrary n snapshot