### PR TITLE
Feature/config learn

### DIFF
--- a/doc/CONFIG.md
+++ b/doc/CONFIG.md
@@ -44,7 +44,8 @@ tracer = $SIBYL/ext/pin_tracer/pin_tracer.so
 
 [learn]
 prune_strategy = branch
-prune_keep = 2
+prune_keep = 1
+prune_keep_max = 5
 ```
 
 ### Section 'find'
@@ -101,6 +102,9 @@ The `prune_strategy` parameter indicates which strategy should be used to prune
 the obtained snapshots. Current supported values are `branch`, `keep`, `keepall`.
 
 The `prune_keep` value specifies the number of snapshot to keep per prunning.
+
+The `prune_keep_map` value specifies the overall maximum number of snapshot to
+keep. `0` means no limit.
 
 Please refer to the related documentation for more information.
 

--- a/sibyl/actions/config.py
+++ b/sibyl/actions/config.py
@@ -76,8 +76,9 @@ class ActionConfig(Action):
             print "PIN tracer not found"
 
         # Learn
-        print "Learn's pruning strategy: %s/%d" % (config.prune_strategy,
-                                                   config.prune_keep)
+        print "Learn's pruning strategy: %s/%d/%d" % (config.prune_strategy,
+                                                      config.prune_keep,
+                                                      config.prune_keep_max)
 
         # Tests
         print "Tests availables:"

--- a/sibyl/actions/learn.py
+++ b/sibyl/actions/learn.py
@@ -42,6 +42,9 @@ class ActionLearn(Action):
         (["-o", "--output"], {"help": "Output file. Class is printed to stdout" \
                               "if no output file is specified.",
                               "default": None}),
+        (["-z", "--avoid-null"], {"help": "If set, do not consider runs "\
+                                  "returning a null value",
+                                  "action": "store_true"}),
     ]
 
     def run(self):
@@ -71,7 +74,7 @@ class ActionLearn(Action):
                                   self.args.program, self.args.headerfile,
                                   AVAILABLE_TRACER[self.args.trace],
                                   AVAILABLE_GENERATOR[self.args.generator],
-                                  main, abi, machine)
+                                  main, abi, machine, self.args.avoid_null)
 
         if self.args.verbose == 0:
             testcreator.logger.setLevel(logging.WARN)

--- a/sibyl/config.py
+++ b/sibyl/config.py
@@ -28,7 +28,8 @@ default_config = {
     "pin_root": "$PIN_ROOT",
     "pin_tracer": "$SIBYL/ext/pin_tracer/pin_tracer.so",
     "prune_strategy": "branch",
-    "prune_keep": 2,
+    "prune_keep": 1,
+    "prune_keep_max": 5,
 }
 
 config_paths = [os.path.join(path, 'sibyl.conf')
@@ -120,10 +121,14 @@ class Config(object):
             if cparser.has_option("learn", "prune_strategy"):
                 self.config["prune_strategy"] = cparser.get("learn",
                                                             "prune_strategy")
-            # prune_keep = 2
+            # prune_keep = 1
             if cparser.has_option("learn", "prune_keep"):
                 self.config["prune_keep"] = cparser.getint("learn",
                                                            "prune_keep")
+            # prune_keep_max = 5
+            if cparser.has_option("learn", "prune_keep_max"):
+                self.config["prune_keep"] = cparser.getint("learn",
+                                                           "prune_keep_max")
 
 
 
@@ -158,6 +163,7 @@ class Config(object):
         out.append("[learn]")
         out.append("prune_strategy = %s" % self.config["prune_strategy"])
         out.append("prune_keep = %d" % self.config["prune_keep"])
+        out.append("prune_keep_max = %d" % self.config["prune_keep_max"])
 
         return out
 
@@ -259,6 +265,11 @@ class Config(object):
     def prune_keep(self):
         """Number of elements to keep for each pruning possibility"""
         return self.config["prune_keep"]
+
+    @property
+    def prune_keep_max(self):
+        """Maximum number of snapshot to keep while pruning"""
+        return self.config["prune_keep_max"]
 
 
 config = Config(default_config, config_paths)

--- a/sibyl/learn/findref.py
+++ b/sibyl/learn/findref.py
@@ -212,7 +212,7 @@ class ExtractRef(object):
         # Update state
         ## Reset cache structures
         self.mdis.job_done.clear()
-        self.symb_ir.blocs.clear()
+        self.symb_ir.blocks.clear()
 
         ## Update current state
         asm_block = self.mdis.dis_bloc(cur_addr)

--- a/sibyl/learn/generator/pythongenerator.py
+++ b/sibyl/learn/generator/pythongenerator.py
@@ -399,7 +399,8 @@ class PythonGenerator(Generator):
                     raise TypeError("An argument should be in the form I, " \
                                     "or {I, XX}")
 
-            self.printer.add_block("self._add_arg(%d, %s)\n" % (i, value))
+            self.printer.add_block("self._add_arg(%d, %s) # arg%d_%s\n" %
+                                   (i, value, i, arg_name))
 
         ## Inputs
         self.printer.add_empty_line()

--- a/sibyl/learn/learn.py
+++ b/sibyl/learn/learn.py
@@ -80,6 +80,10 @@ class TestCreator(object):
                 else:
                     ignored += 1
                 already_keeped[path] = current + 1
+                if config.prune_keep_max and len(trace) >= config.prune_keep_max:
+                    self.logger.info("Max number of snapshot reached!")
+                    break
+
         elif config.prune_strategy == "keepall":
             # Do not remove any snapshot
             trace = list(self.trace_iter)

--- a/sibyl/learn/learn.py
+++ b/sibyl/learn/learn.py
@@ -17,7 +17,8 @@ class TestCreator(object):
     """Class used to create a test. Each instance is dedicated to only one learned function"""
 
     def __init__(self, functionname, address, program, header_filename,
-                 tracer_class, generator_class, main_address, abicls, machine):
+                 tracer_class, generator_class, main_address, abicls, machine,
+                 avoid_null):
         """
         @functionname: name of the symbol of the learned function
         @address: address of the learned function in the program
@@ -28,6 +29,7 @@ class TestCreator(object):
         @main_address: address where the tracer has to begin, if none the tracer begins at the entry point
         @abicls: class of the ABI used by the program
         @machine: machine used by the program
+        @avoid_null: if set, do not consider snapshots returning a null value
         """
         self.functionname = functionname
         self.address = address
@@ -39,6 +41,7 @@ class TestCreator(object):
         self.abicls = abicls
         self.machine = machine
         self.types = None
+        self.avoid_null = avoid_null
 
         self.learnexceptiontext = []
 
@@ -72,6 +75,11 @@ class TestCreator(object):
             ignored = 0
             already_keeped = {} # path -> seen number
             for snapshot in self.trace_iter:
+                # TODO use abi
+                if self.avoid_null and snapshot.output_reg["RAX"] == 0:
+                    ignored += 1
+                    continue
+
                 path = frozenset(snapshot.paths.edges())
                 current = already_keeped.get(path, 0)
                 if current < config.prune_keep:


### PR DESCRIPTION
Add 2 new possibilities to restrict what runs are keeped during learning:
* `prune_keep_max`: maximum overall number of runs to keep (avoid aving too heavy tests on function with complex CFG)
* `avoid_null` option to drop tests returning a zero value (often encountered in libs testset, for instance testing mul with (0, 0), (0, a), (a, 0), ... -> false positive)