### PR TITLE
Fix regex when function returns a pointer

### DIFF
--- a/ext/ida/find.py
+++ b/ext/ida/find.py
@@ -266,7 +266,7 @@ Testsets to use:
     }
 
     # int __cdecl(int, int) -> __cdecl
-    gtype_matcher = re.compile(".+ ([^\(]+)\([^\)]*\)")
+    gtype_matcher = re.compile(".+ \*?([^\(]+)\([^\)]*\)")
 
     @property
     def abi(self):


### PR DESCRIPTION
Hello,

There is an issue with the IDA stub when a function returns a pointer. 

For example the regex `.+ ([^\(]+)\([^\)]*\)` matches `*__cdecl` instead of `__cdecl`.

This can be resolved with the attached fix.

 